### PR TITLE
add CSV-separated job run causes to RunMessage

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pubsub/EventProps.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/EventProps.java
@@ -135,6 +135,10 @@ public interface EventProps {
          * Job run SCM commit Id, if relevant.
          */
         job_run_commitId,
+        /**
+         * Causes of this run.
+         */
+        job_run_causes
     }
     
     /**

--- a/src/main/java/org/jenkinsci/plugins/pubsub/RunMessage.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/RunMessage.java
@@ -23,15 +23,19 @@
  */
 package org.jenkinsci.plugins.pubsub;
 
+import hudson.model.Cause;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.security.AccessControlled;
+import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Jenkins {@link Run} domain model {@link PubsubBus} message instance.
@@ -62,6 +66,13 @@ public final class RunMessage extends JobChannelMessage<RunMessage> {
         set(EventProps.Jenkins.jenkins_object_id, run.getId());
         set(EventProps.Jenkins.jenkins_object_url, run.getUrl());
         set(EventProps.Job.job_run_queueId, Long.toString(run.getQueueId()));
+
+        // CSV list of the accumulated causes of this run
+        final List<String> causes = new ArrayList<>();
+        for (Cause cause : (List<Cause>) run.getCauses()) {
+            causes.add(cause.getClass().getSimpleName());
+        }
+        set(EventProps.Job.job_run_causes, StringUtils.join(causes, ","));
 
         Result result = run.getResult();
         if (result != null) {

--- a/src/main/java/org/jenkinsci/plugins/pubsub/RunMessage.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/RunMessage.java
@@ -67,13 +67,6 @@ public final class RunMessage extends JobChannelMessage<RunMessage> {
         set(EventProps.Jenkins.jenkins_object_url, run.getUrl());
         set(EventProps.Job.job_run_queueId, Long.toString(run.getQueueId()));
 
-        // CSV list of the accumulated causes of this run
-        final List<String> causes = new ArrayList<>();
-        for (Cause cause : (List<Cause>) run.getCauses()) {
-            causes.add(cause.getClass().getSimpleName());
-        }
-        set(EventProps.Job.job_run_causes, StringUtils.join(causes, ","));
-
         Result result = run.getResult();
         if (result != null) {
             set(EventProps.Job.job_run_status, result.toString());
@@ -128,5 +121,15 @@ public final class RunMessage extends JobChannelMessage<RunMessage> {
             runLookupComplete = true;
         }
         return run;
+    }
+
+    public RunMessage withCauses(@Nonnull Run run) {
+        // CSV list of the accumulated causes of this run
+        final List<String> causes = new ArrayList<>();
+        for (Cause cause : (List<Cause>) run.getCauses()) {
+            causes.add(cause.getClass().getSimpleName());
+        }
+        set(EventProps.Job.job_run_causes, StringUtils.join(causes, ","));
+        return this;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/pubsub/listeners/SyncRunListener.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/listeners/SyncRunListener.java
@@ -54,8 +54,10 @@ public class SyncRunListener extends RunListener<Run<?,?>> {
     @Override
     public void onStarted(Run<?, ?> run, TaskListener listener) {
         try {
-            PubsubBus.getBus().publish(new RunMessage(run)
-                    .setEventName(Events.JobChannel.job_run_started)
+            PubsubBus.getBus().publish(
+                    new RunMessage(run)
+                        .withCauses(run)
+                        .setEventName(Events.JobChannel.job_run_started)
             );
         } catch (MessageException e) {
             LOGGER.log(Level.WARNING, "Error publishing Run start event.", e);


### PR DESCRIPTION
# Description

Adds a CSV-separated list of run cause simple class names for downstream consumers to decide if they want to consume these events or not.

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
