### PR TITLE
Prevent resource leak in tests by shutting down with the webapp not the JVM

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pubsub/PubsubBus.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/PubsubBus.java
@@ -26,16 +26,18 @@ package org.jenkinsci.plugins.pubsub;
 import hudson.ExtensionList;
 import hudson.ExtensionListListener;
 import hudson.ExtensionPoint;
+import hudson.init.Terminator;
 import hudson.security.AccessControlled;
-import org.acegisecurity.Authentication;
-import org.jenkinsci.plugins.pubsub.listeners.SyncQueueListener;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.acegisecurity.Authentication;
+import org.jenkinsci.plugins.pubsub.listeners.SyncQueueListener;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 /**
  * Abstract Pub-sub bus.
@@ -48,20 +50,44 @@ public abstract class PubsubBus implements ExtensionPoint {
 
     private static List<AbstractChannelSubscriber> autoSubscribers = new CopyOnWriteArrayList<>();
 
+    private static final Object shutdownHookLock = new Object();
+    private static Thread shutdownHook;
+
     static {
-        Runtime.getRuntime().addShutdownHook( new Thread(() -> {
-                try {
-                    SyncQueueListener.shutdown();
-                } finally {
-                    if (Holder.pubsubBus != null) {
-                        try {
-                            unregisterAutoChannelSubscribers(Holder.pubsubBus);
-                        } finally {
-                            Holder.pubsubBus.shutdown();
-                        }
+        shutdownHook = new Thread(() -> {
+            synchronized (shutdownHookLock) {
+                shutdownHook = null;
+            }
+            try {
+                SyncQueueListener.shutdown();
+            } finally {
+                if (Holder.pubsubBus != null) {
+                    try {
+                        unregisterAutoChannelSubscribers(Holder.pubsubBus);
+                    } finally {
+                        Holder.pubsubBus.shutdown();
                     }
                 }
-        }));
+            }
+        });
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+    }
+
+    @Terminator()
+    @Restricted(NoExternalUse.class)
+    public static void shutdownEarly() throws InterruptedException {
+        Thread shutdownHook;
+        synchronized (shutdownHookLock) {
+            shutdownHook = PubsubBus.shutdownHook;
+            PubsubBus.shutdownHook = null;
+            if (shutdownHook != null) {
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
+            }
+        }
+        if (shutdownHook != null) {
+            shutdownHook.start();
+            shutdownHook.join();
+        }
     }
 
     private static final class Holder {


### PR DESCRIPTION
# Description

While debugging why some tests were running a long time I noticed that the thread resources started by this plugin are not being shutdown with the webapp rather being shutdown with the JVM... which is not the best plan.

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given