### PR TITLE
Make message and AccessControlledMessage public so they can be used by other plugins

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pubsub/AccessControlledMessage.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/AccessControlledMessage.java
@@ -54,12 +54,13 @@ import javax.annotation.Nonnull;
  * 
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
-abstract class AccessControlledMessage<T extends AccessControlledMessage> extends Message implements AccessControlled {
+abstract public class AccessControlledMessage<T extends AccessControlledMessage> extends Message implements AccessControlled {
     
     /**
      * Create a plain message instance.
      */
-    AccessControlledMessage() {
+    public AccessControlledMessage() {
+      super();
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/pubsub/Message.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/Message.java
@@ -95,7 +95,7 @@ public abstract class Message<T extends Message> extends Properties {
     /**
      * Create a plain message instance, with default properties set.
      */
-    Message() {
+    public Message() {
         this(true);
     }
 
@@ -103,7 +103,7 @@ public abstract class Message<T extends Message> extends Properties {
      * Create a plain message instance.
      * @param setDefaultProperties Set the default properties.
      */
-    Message(boolean setDefaultProperties) {
+    public Message(boolean setDefaultProperties) {
         if (!setDefaultProperties) {
             return;
         }


### PR DESCRIPTION
Does changing access levels need tests?

Looking to add pubsub support to favorites, and while I was doing so, I couldn't figure out how to make my own message type, especially one that didn't broadcast all fav changes that all users did to the entire system (should it do so?)


# Submitter checklist
- [N/A] Link to JIRA ticket in description, if appropriate.
- [X] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

