### PR TITLE
Migrate Plugin documentation from Wiki to GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Release Notes
+
+## 1.13
+
+Release date: (Aug 16, 2019)
+
+-   Add convenient method to restart bus.
+-   use holder singleton pattern to avoid multiple creating issue
+
+## 1.12
+
+Release date: (Jul 18, 2017)
+
+-   Roll forward, fixing regression discovered in 1.9/1.10.
+
+## 1.11
+
+Release date: (Jul 13, 2017)
+
+-   Rollback to 1.8 due to regression discovered in 1.9/1.10.
+
+## 1.10
+
+Release date: (Jul 7, 2017)
+
+-   job\_run\_artifact\_fingerprinting event
+
+## 1.9
+
+Release date: (Jul 6, 2017)
+
+-   jenkins\_instance\_id and jenkins\_instance\_url event properties
+
+## 1.8
+
+Release date: (May 8, 2017)
+
+-   Folder indexing events.
+-   Added AbstractChannelSubscriber
+
+## 1.7
+
+Release date: (Feb 8, 2017)
+
+-   [JENKINS-41832](https://issues.jenkins-ci.org/browse/JENKINS-41832):
+    Fix out-of-control thread spin causing machines to melt.
+
+## 1.6
+
+Release date: (Jan 26, 2017)
+
+-   [JENKINS-41487](https://issues.jenkins-ci.org/browse/JENKINS-41487):
+    Getting the plugin to appear in the Update Centre.
+
+## 1.5
+
+Release date: (Jan 26, 2017)
+
+-   First release as a HPI. Used to be a jenkins-module.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+Pub-Sub "light" Bus plugin for Jenkins
+======================================
+
 A light-weight [Publish-Subscribe](http://www.enterpriseintegrationpatterns.com/patterns/messaging/PublishSubscribeChannel.html) (async) event notification module for Jenkins.
 
 Contains the `org.jenkins.pubsub.PubsubBus` abstract class, which is a Jenkins `ExtensionPoint`, with a default
@@ -8,6 +11,10 @@ implementation based on [Google's Guava EventBus](https://github.com/google/guav
 # API
 
 Please [see the online Javadoc](http://jenkinsci.github.io/pubsub-light-plugin/) for how to use the API.
+
+# Release notes
+
+See [CHANELOG.md](./CHANGELOG.md)
 
 # This is not a full-blown Event Bus
  

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <name>Jenkins Pub-Sub "light" Bus</name>
   <description>A simple Publish-Subscribe light-weight event bus for Jenkins</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/PubSub+Light+Plugin</url>
+  <url>https://github.com/jenkinsci/pubsub-light-plugin</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
# Description

See https://jenkins.io/blog/2019/10/21/plugin-docs-on-github . It moves all Wiki contents to GitHub

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
