### PR TITLE
Remove local instances of Item, Jenkins. Queue.Item

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pubsub/Message.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/Message.java
@@ -78,13 +78,14 @@ public abstract class Message<T extends Message> extends Properties {
     private static final String instanceRootUrl;
 
     static {
-        if (Jenkins.getInstanceOrNull() != null) {
+        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins != null) {
             // As implemented in PageDecoratorImpl.java in the instance-identity-module.
             // Would have been nice if there was a utility/toString() for this.
             InstanceIdentity identity = InstanceIdentity.get();
             RSAPublicKey key = identity.getPublic();
             instanceIdentity = new String(Base64.encodeBase64(key.getEncoded()), StandardCharsets.UTF_8);
-            instanceRootUrl = Jenkins.get().getRootUrl();
+            instanceRootUrl = jenkins.getRootUrl();
         } else {
             instanceIdentity = null;
             instanceRootUrl = null;

--- a/src/main/java/org/jenkinsci/plugins/pubsub/Message.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/Message.java
@@ -74,18 +74,17 @@ import java.util.UUID;
  */
 public abstract class Message<T extends Message> extends Properties {
 
-    private static final Jenkins jenkins = Jenkins.getInstanceOrNull();
     private static final String instanceIdentity;
     private static final String instanceRootUrl;
 
     static {
-        if (jenkins != null) {
+        if (Jenkins.getInstanceOrNull() != null) {
             // As implemented in PageDecoratorImpl.java in the instance-identity-module.
             // Would have been nice if there was a utility/toString() for this.
             InstanceIdentity identity = InstanceIdentity.get();
             RSAPublicKey key = identity.getPublic();
             instanceIdentity = new String(Base64.encodeBase64(key.getEncoded()), StandardCharsets.UTF_8);
-            instanceRootUrl = jenkins.getRootUrl();
+            instanceRootUrl = Jenkins.get().getRootUrl();
         } else {
             instanceIdentity = null;
             instanceRootUrl = null;

--- a/src/main/java/org/jenkinsci/plugins/pubsub/QueueTaskMessage.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/QueueTaskMessage.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.pubsub;
 
 import hudson.model.Item;
 import hudson.model.Queue;
+import jenkins.model.Jenkins;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -38,19 +39,24 @@ public final class QueueTaskMessage extends JobChannelMessage<QueueTaskMessage> 
 
     private static final long serialVersionUID = -1L;
 
-    transient Queue.Item queueItem;
+    transient Long queueItemId = null;
 
     public QueueTaskMessage() {
     }
 
     public QueueTaskMessage(@Nonnull Queue.Item item, @Nonnull Item jobChannelItem) {
         super(jobChannelItem);
-        this.queueItem = item;
+        this.queueItemId = item.getId();
     }
 
+    public QueueTaskMessage(@Nonnull Long itemId, @Nonnull Item jobChannelItem) {
+        super(jobChannelItem);
+        this.queueItemId = itemId;
+    }
+    
     @CheckForNull
     public Queue.Item getQueueItem() {
-        return queueItem;
+        return Queue.getInstance().getItem(queueItemId);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/pubsub/QueueTaskMessage.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/QueueTaskMessage.java
@@ -56,7 +56,7 @@ public final class QueueTaskMessage extends JobChannelMessage<QueueTaskMessage> 
     
     @CheckForNull
     public Queue.Item getQueueItem() {
-        return Queue.getInstance().getItem(queueItemId);
+        return queueItemId != null ? Queue.getInstance().getItem(queueItemId) : null;
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/pubsub/GuavaPubsubBusRunTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pubsub/GuavaPubsubBusRunTest.java
@@ -95,16 +95,16 @@ public class GuavaPubsubBusRunTest {
             RunMessage runMessage = (RunMessage) aliceSubs.messages.get(4);
 
             // The domain model object instances should not be on the messages...
-            assertNull(queueMessage.jobChannelItem);
-            assertNull(runMessage.jobChannelItem);
+            assertNull(queueMessage.jobChannelItemFullName);
+            assertNull(runMessage.jobChannelItemFullName);
             assertNull(runMessage.run);
             // But calling the getter methods should result in them being looked up...
             queueMessage.getJobChannelItem();
             runMessage.getRun();
-            assertNotNull(queueMessage.jobChannelItem);
-            assertNotNull(runMessage.jobChannelItem);
+            assertNotNull(queueMessage.jobChannelItemFullName);
+            assertNotNull(runMessage.jobChannelItemFullName);
             assertNotNull(runMessage.run);
-            assertEquals(queueMessage.jobChannelItem, runMessage.jobChannelItem);
+            assertEquals(queueMessage.jobChannelItemFullName, runMessage.jobChannelItemFullName);
             
             // And check that the queue Ids match
             assertEquals(queueMessage.get(EventProps.Job.job_run_queueId), runMessage.get(EventProps.Job.job_run_queueId));


### PR DESCRIPTION
# Description
I see this plugin in heap dumps with a lot of memory allocated. Mainly because it declares a variable with the Jenkins object. In addition there are some reports marking the plugin as culprit because the memory consumption and the instance gets OOME. This PR is an attempt to remove the allocated jenkins objects to avoid issues with Items not being able to be garbage allocated or being shown in the heap dumps.

Basically I remove Jenkins, Item or Queue.Item and I use their IDs to get them from the Jenkins or Queue objects when needed.

@jtnord @alecharp @rsandell @olamy @bitwiseman @car-roll @jglick 

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
