### PR TITLE
Update GitHub URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,9 @@
   </properties>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/pubsub-light-module.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/pubsub-light-module.git</developerConnection>
-    <url>https://github.com/jenkinsci/pubsub-light-module</url>
+    <connection>scm:git:git://github.com/jenkinsci/pubsub-light-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/pubsub-light-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/pubsub-light-plugin</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
This should fix some metadata processing problems that currently cause docs only being shown as a link at https://plugins.jenkins.io/pubsub-light/