### PR TITLE
Test with Java 21

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux', jdk: 11],
-  [platform: 'windows', jdk: 11],
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.73</version>
+    <version>4.74</version>
     <relativePath />
   </parent>
   

--- a/src/main/java/org/jenkinsci/plugins/pubsub/AccessControlledMessage.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/AccessControlledMessage.java
@@ -46,7 +46,7 @@ import org.springframework.security.core.Authentication;
  * to see those events. This {@link Message} is geared at helping in these
  * situations.
  * 
- * <h1>PubsubBus implementations</h1>
+ * <h2>PubsubBus implementations</h2>
  * {@link PubsubBus} implementations should watch for this message subtype,
  * calling the relevant Jenkins security APIs as appropriate
  * ({@link ACL#as2(Authentication)}, {@link AccessControlled} etc).

--- a/src/main/java/org/jenkinsci/plugins/pubsub/Message.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/Message.java
@@ -44,7 +44,7 @@ import java.util.UUID;
 /**
  * {@link PubsubBus} message instance.
  * 
- * <h1>Light-weight messages</h1>
+ * <h2>Light-weight messages</h2>
  * We purposely chose a very simple {@link Properties} based extension for the message
  * type, so as to avoid marshal/unmarshal issues with more complex message type
  * (the {@link PubsubBus} implementation could be distributed). It is also hoped that
@@ -63,7 +63,7 @@ import java.util.UUID;
  * <p>
  * <strong>Note</strong> the {@link AccessControlledMessage} subtype.
  *  
- * <h1>Event property namespaces</h1>
+ * <h2>Event property namespaces</h2>
  * Event property names are opaque {@link String}s. Any {@link String} is valid, but
  * we do recommend using valid underscores to namespace e.g. "a_b_c". 
  * This will help to avoid name collisions.


### PR DESCRIPTION
## Test with Java 21

Java 21 was released Sep 19, 2023. We want to announce full support for Java 21 in early October and would like the most used plugins to be compiled and tested with Java 21.

The acceptance test harness and plugin bill of materials tests are already passing with Java 21. This is a further step to improve plugin readiness for use with Java 21 and for development with Java 21.

The change intentionally tests only two Java configurations, Java 17 and Java 21 because we believe that the risk of a regression that only affects Java 11 is low. We generate Java 11 byte code with the Java 17 and the Java 21 builds, so we're already testing Java 11 byte code.

Includes pull requests:

* #114
* #113

### Manual test instructions

Tested with Java 21 on Linux.  Rely on ci.jenkins.io to test Java 17 on Windows.

# Submitter checklist
- [x] Change is code complete and matches issue description
- [x] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [x] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given
